### PR TITLE
Longer test run for JAGS 5.0.0

### DIFF
--- a/tests/testthat/test-hb_ess.R
+++ b/tests/testthat/test-hb_ess.R
@@ -7,16 +7,16 @@ test_that("hb_ess()", {
   pool <- hb_mcmc_pool(
     data,
     n_chains = 1,
-    n_adapt = 100,
-    n_warmup = 50,
-    n_iterations = 50
+    n_adapt = 1000,
+    n_warmup = 500,
+    n_iterations = 1000
   )
   hierarchical <- hb_mcmc_hierarchical(
     data,
     n_chains = 1,
-    n_adapt = 100,
-    n_warmup = 50,
-    n_iterations = 50
+    n_adapt = 1000,
+    n_warmup = 500,
+    n_iterations = 1000
   )
   out <- hb_ess(
     mcmc_pool = pool,


### PR DESCRIPTION
In preparation for the release of JAGS 5.0.0 I am testing the reverse dependencies of the rjags package on CRAN.

For historicalborrow everything is fine except for one of the tests which fails. My diagnosis is that the test run is too short and the Monte Carlo error is still too large for the given tolerance. The test passes if I make the simulation run longer. The numbers here are just a suggestion. 